### PR TITLE
Update scatter_add to use full batch

### DIFF
--- a/SuScore/model/utils.py
+++ b/SuScore/model/utils.py
@@ -685,8 +685,7 @@ def run_an_eval_epoch(model, data_loader, pred=False, atom_contribution=False, r
                     y = scatter_add(prob, batch[th.where(dist <= dist_threhold)[0]], dim=0,
                                     dim_size=batch.unique().size(0))
                 else:
-                    y = scatter_add(prob, batch[th.where(dist <= dist_threhold)[0]], dim=0,
-                                    dim_size=batch.unique().size(0))
+					y = scatter_add(prob, batch, dim=0, dim_size=batch.unique().size(0)).to(th.float32)
                 labels = labels.float().type_as(y).to(device)
 
                 affi = th.corrcoef(th.stack([y, labels]))[1, 0]

--- a/scripts/PDE_train.py
+++ b/scripts/PDE_train.py
@@ -6,7 +6,7 @@ import sys
 
 sys.path.append("") # your program
 from SuScore.data.data import PDBbindDataset
-from SuScore.model.ET_MDN import LumiScore, GraphTransformer, SubGT
+from SuScore.model.ET_MDN import GenScore, GraphTransformer, SubGT
 from SuScore.model.mdn_utils import EarlyStopping, set_random_seed, run_a_train_epoch, run_an_eval_epoch, mdn_loss_fn, \
     GIP_train_epoch, GIP_eval_epoch, GIP_semi_label
 from fep_score import fep_score


### PR DESCRIPTION
Refactor scatter_add call to use the entire batch instead of a filtered subset based on distance threshold.